### PR TITLE
feat: Add a isGlobal option

### DIFF
--- a/src/oso.module.ts
+++ b/src/oso.module.ts
@@ -7,6 +7,7 @@ export interface OsoModuleConfig {
   loadStr?: string;
   loadFile?: string;
   osoOptions?: Options;
+  isGlobal?: boolean; // If true, registers `OsoModule` as a global module.
 }
 
 @Module({
@@ -18,6 +19,7 @@ export class OsoModule {
 
   static forRoot(options: OsoModuleConfig = {}): DynamicModule {
     return {
+      global: options.isGlobal,
       module: OsoModule,
       providers: [
         {


### PR DESCRIPTION
Originally, I forked [bjerkio/nestjs-oso](https://github.com/bjerkio/nestjs-oso) to youngjoon-lee/nestjs-oso(https://github.com/youngjoon-lee/nestjs-oso), but I would be better to fork it to this `medibloc/nestjs-oso`.

I already made a PR to `bjerkio/nestjs-oso` based on my `youngjoon-lee/nestjs-oso`, which is the same as this PR.

Until it's merged, let's merge this PR to the main branch of this `medibloc/nestjs-oso`, and publish it to npm as `@medibloc/nestjs-oso`.